### PR TITLE
[fix] restart service after 1 sec (not 1000 secs)

### DIFF
--- a/websocket-proxy.service
+++ b/websocket-proxy.service
@@ -8,7 +8,7 @@ After=network.target
 ExecStart=node client
 Restart=always
 # delay between restart executions
-RestartSec=1000
+RestartSec=1
 # how many times to try to restart the service in StartLimitIntervalSec
 # StartLimitBurst=
 # StartLimitIntervalSec=


### PR DESCRIPTION
Restart interval of systemd service was set to 1000 seconds (cca 17 minutes) instead of 1 second. This fix will highly increase connectivity for all WS proxy clients which uses the default settings.